### PR TITLE
Spotify player control in background implemented

### DIFF
--- a/lib/managers/Spotify.dart
+++ b/lib/managers/Spotify.dart
@@ -291,7 +291,9 @@ playSpotifyTrack(String _uri, String _url) async {
       }));
 
   if (response.statusCode == 200) {
-    print("playing $_uri!");
+    print("opening $_uri in spotify");
+  } else if (response.statusCode == 204) {
+    print("playing $_uri in background");
   } else if (response.statusCode == 404) {
     return launch(_url);
   } else {

--- a/lib/managers/Spotify.dart
+++ b/lib/managers/Spotify.dart
@@ -262,6 +262,20 @@ Future<void> loadTodaysTracks() async {
   }
 }
 
+playSpotifyTrack(String _url) async {
+  print("sending $_url to spotify...");
+
+  final response = await http.put('https://api.spotify.com/v1/me/player/play',
+      headers: {'Authorization': 'Bearer ' + _authenticationToken},
+      body: {"context_uri": "spotify:album:5ht7ItJgpBH7W6vJ5BqpPr"});
+
+  if (response.statusCode == 200) {
+    print("playing $_url!");
+  } else {
+    print("Error playing track");
+  }
+}
+
 // FETCHING MORE THAN 5 tracks - need to use next???
 // final response2 = await http.get(
 //     "https://api.spotify.com/v1/me/player/recently-played?before=1607392056792&limit=5",

--- a/lib/views/DiaryEntryView.dart
+++ b/lib/views/DiaryEntryView.dart
@@ -1209,8 +1209,8 @@ class _DiaryEntryViewState extends State<DiaryEntryView> {
                 icon: Icon(Icons.play_circle_fill,
                     color: Colors.green, size: 50.0),
                 onPressed: () {
-                  // open in spotify
-                  return launch(_storedTrack.url);
+                  // play in spotify
+                  _playSpotifyTrack();
                 }));
   }
 
@@ -1226,8 +1226,8 @@ class _DiaryEntryViewState extends State<DiaryEntryView> {
   }
 
   _playSpotifyTrack() async {
-    if (_storedTrack.url != null) {
-      print("shall I play ${_storedTrack.url}");
+    if (_storedTrack.uri != null) {
+      await playSpotifyTrack(_storedTrack.uri, _storedTrack.url);
     }
   }
 

--- a/lib/views/DiaryEntryView.dart
+++ b/lib/views/DiaryEntryView.dart
@@ -1225,6 +1225,16 @@ class _DiaryEntryViewState extends State<DiaryEntryView> {
     }
   }
 
+  _playSpotifyTrack() async {
+    if (_storedTrack.url != null) {
+      print("shall I play ${_storedTrack.url}");
+    }
+  }
+
+  ///////////////////////////////////////////////////////////////////////
+  /// SPOTIFY
+///////////////////////////////////////////////////////////////////////
+
   Widget callAction() {
     if (_isEditingText == true) return _saveButton();
     if (_isEditingText == false && ownerId != _user.uid)
@@ -1232,10 +1242,6 @@ class _DiaryEntryViewState extends State<DiaryEntryView> {
     else
       return _editButton();
   }
-
-///////////////////////////////////////////////////////////////////////
-  /// SPOTIFY
-///////////////////////////////////////////////////////////////////////
 
 ///////////////////////////////////////////////////////////////////////
   /// DELETE ENTRY

--- a/lib/views/timeline/TimeLineView.dart
+++ b/lib/views/timeline/TimeLineView.dart
@@ -41,7 +41,8 @@ class _TimeLineView extends State<TimeLineView> {
         "artist": null,
         "track": null,
         "albumImage": null,
-        "url": null, // to open in spotify
+        "url": null, // to open spotify
+        "uri": null, // to play in background
       },
       "shared_with": [],
       "user_name": "",
@@ -62,6 +63,7 @@ class _TimeLineView extends State<TimeLineView> {
             entry["content"]["artist"] = _storedTrack.artist,
             entry["content"]["albumImage"] = _storedTrack.imageUrl,
             entry["content"]["url"] = _storedTrack.url,
+            entry["content"]["uri"] = _storedTrack.uri
           });
     }
     if (mounted)
@@ -203,6 +205,12 @@ class _TimeLineView extends State<TimeLineView> {
     );
   }
 
+  _playSpotifyTrack(_url, _uri) async {
+    if (_uri != null) {
+      await playSpotifyTrack(_url, _uri);
+    }
+  }
+
   Widget createListView(
       BuildContext context, List<Map<String, dynamic>> entries) {
     if (!mounted) return null;
@@ -300,8 +308,10 @@ class _TimeLineView extends State<TimeLineView> {
                     icon: Icon(Icons.play_circle_fill,
                         color: Colors.green, size: 50.0),
                     onPressed: () {
-                      // open in spotify
-                      return launch(entry["content"]["url"]);
+                      // play in spotify
+                      _playSpotifyTrack(
+                          entry["content"]["url"], entry["content"]["uri"]);
+                      //return launch(entry["content"]["url"]);
                     }),
                 isThreeLine: true,
               ),


### PR DESCRIPTION
- Clicking play on a song plays song in background IF spotify is already open
- If spotify is closed, clicking play opens spotify link like before
- No changes to existing UI

Sometimes if you play a song on inkling right after opening spotify, it will still open up the app because it doesn't detect it's already open - spotify API takes a second to update I guess. But otherwise, seems to work fine after testing!

For now, no pause/resume functionality within inkling itself, but could try to knock that out tomorrow.
(Though I found a different spotify x timeline related bug that I'll open as a separate issue)

